### PR TITLE
Security fix for Prototype Pollution in obj-unflatten

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ module.exports = function unflattenObject(flatten, separator) {
           ;
 
         iterateObject(subkeys, subkey => {
-          if (subkey == '__proto__' || subkey == 'constructor' || subkey == 'prototype')
+            if (subkey == '__proto__' || subkey == 'constructor' || subkey == 'prototype')
                 return
             parentObj[subkey] = isUndefined(parentObj[subkey])
                               ? {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,8 @@ module.exports = function unflattenObject(flatten, separator) {
           ;
 
         iterateObject(subkeys, subkey => {
+          if (subkey == '__proto__' || subkey == 'constructor' || subkey == 'prototype')
+                return
             parentObj[subkey] = isUndefined(parentObj[subkey])
                               ? {}
                               : parentObj[subkey]


### PR DESCRIPTION
### 📊 Metadata *

`obj-unflatten` convert flatten objects in nested ones. This package is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-unflatten

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fix implemented by not allowing to modify object prototype.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
const unflatten = require('obj-unflatten')
console.log('Before: ' + {}.polluted)
unflatten({'__proto__.polluted': 'Prototype Polluted!'})
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in the terminal:
```bash
npm i obj-unflatten # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: Prototype Polluted!
```

### 🔥 Proof of Fix (PoF)

![image](https://user-images.githubusercontent.com/43996156/102465402-9af38780-4073-11eb-8c5e-719742bae9ed.png)

### 👍 User Acceptance Testing

* I've executed unit tests.
* After fix the functionality is unaffected.
