### PR TITLE
Prototype pollution fix - checking magic attributes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,16 @@ const iterateObject = require("iterate-object")
     , isUndefined = require("is-undefined")
     ;
 
+
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key key for check, string.
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
 /**
  * unflattenObject
  * Convert flatten objects in nested ones.
@@ -28,6 +38,8 @@ module.exports = function unflattenObject(flatten, separator) {
           ;
 
         iterateObject(subkeys, subkey => {
+          if (isPrototypePolluted(subkey)) return;
+
             parentObj[subkey] = isUndefined(parentObj[subkey])
                               ? {}
                               : parentObj[subkey]


### PR DESCRIPTION
### 📊 Metadata *

obj-unflatten convert flatten objects in nested ones. This package is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-unflatten

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
const unflatten = require('obj-unflatten')
console.log('Before: ' + {}.polluted)
unflatten({'__proto__.polluted': 'Prototype Polluted!'})
console.log('After: ' + {}.polluted)
```

Execute the following commands in the terminal:

```
npm i obj-unflatten # install vulnerable package
node poc.js # run the PoC
```

Check the output:

```
Before: undefined
After: Prototype Polluted!
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/102465613-e1e17d00-4073-11eb-9794-3b4a8ae30af3.png)

After:
![image](https://user-images.githubusercontent.com/64132745/102465670-f6257a00-4073-11eb-8be9-7c40328108ff.png)


### 👍 User Acceptance Testing (UAT)

After fix, the functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1407
